### PR TITLE
Update service-account.yaml to remove duplication

### DIFF
--- a/hcl-commerce-helmchart/stable/hcl-commerce/templates/service-account.yaml
+++ b/hcl-commerce-helmchart/stable/hcl-commerce/templates/service-account.yaml
@@ -12,7 +12,6 @@ metadata:
     {{- end }}
     "helm.sh/hook-weight": "0"
   labels:
-    app.kubernetes.io/name: HCL-Commerce
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "-" | replace "+" "-" }}
     app.kubernetes.io/name: {{ include "name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}


### PR DESCRIPTION
I want to use Kustomize on top of hcl-commerce helm chart but it fails due to a duplicate line in service-account.yaml file.

Error Message:
```
error: map[string]interface {}(nil): yaml: unmarshal errors: line 10: mapping key "app.kubernetes.io/name" already defined at line 8
```

Steps to reproduce:
Run the following commands:
`helm template . > all.yaml`
`kubectl kustomize .`

You can use a basic kustomization file for this purpose.

